### PR TITLE
Generate extended public keys from an extended key

### DIFF
--- a/hd-wallet-derive.php
+++ b/hd-wallet-derive.php
@@ -50,6 +50,12 @@ function main()
             return 0;
         }
 
+        if (@$params['get-extended']) {
+            $result = $walletDerive->getExtendedPublicKeys($key);
+            WalletDeriveReport::printResults($params, $result);
+            return 0;
+        }
+
         // Key derived from mnemonic if mnemonic is choosen
         if( !@$params['key'] && @$params['mnemonic'] && !@$orig_params['path'] && !@$orig_params['preset']) {
             $path = $walletDerive->getCoinBip44ExtKeyPathPurposeByKeyType($params['coin'], $params['key-type']);

--- a/hd-wallet-derive.php
+++ b/hd-wallet-derive.php
@@ -50,12 +50,6 @@ function main()
             return 0;
         }
 
-        if (@$params['get-extended']) {
-            $result = $walletDerive->getExtendedPublicKeys($key);
-            WalletDeriveReport::printResults($params, $result);
-            return 0;
-        }
-
         // Key derived from mnemonic if mnemonic is choosen
         if( !@$params['key'] && @$params['mnemonic'] && !@$orig_params['path'] && !@$orig_params['preset']) {
             $path = $walletDerive->getCoinBip44ExtKeyPathPurposeByKeyType($params['coin'], $params['key-type']);
@@ -68,6 +62,13 @@ function main()
             }
         }
         $key = @$params['key'] ?: $walletDerive->mnemonicToKey($params['coin'], $params['mnemonic'], $params['key-type'], $params['mnemonic-pw']);
+        
+        if (@$params['gen-extended']) {
+            $result = $walletDerive->getExtendedPublicKeys($key);
+            WalletDeriveReport::printResults($params, $result, true);
+            return 0;
+        }
+
         $addrs = $walletDerive->derive_keys($key);
 
         // Prints result

--- a/src/Utils/Util.php
+++ b/src/Utils/Util.php
@@ -35,7 +35,7 @@ class Util
             'list-cols',
             'bch-format:',
             'alt-extended:',
-            'gen-key', 'gen-key-all',
+            'gen-key', 'gen-key-all', 'gen-extended',
             'gen-words:',
             'version', 'help', 'help-coins',
             'preset:', 'path-change', 'path-account:', 'help-presets',
@@ -95,6 +95,7 @@ class Util
 
         $params['gen-key'] = isset($params['gen-key']) || isset($params['gen-words']);
         $params['gen-key-all'] = isset($params['gen-key-all']);  // hidden param, for the truly worthy who read the code.
+        $params['gen-extended'] = isset($params['gen-extended']);
         $key = @$params['key'];
         $mnemonic = @$params['mnemonic'];
 
@@ -284,6 +285,7 @@ class Util
                                                     
     --includeroot       include root key as first element of report.
     --gen-key           generates a new key.
+    --gen-extended      generate the coresponding x, y or z public keys from a provided key
     --gen-words=<n>     num words to generate. implies --gen-key.
                            one of: [$allowed_numwords]
                            default = 24.


### PR DESCRIPTION
Given an extended public/private key generate the corresponding extended public keys in "legacy", "p2sh-segwit" or "bech32" address types (if supported)
These can then be used by hd-addr to check the generated addresses for funds as mentioned in issue #28 .