### PR TITLE
Fix php7.4 deprecation warnings

### DIFF
--- a/src/Utils/MyLogger.php
+++ b/src/Utils/MyLogger.php
@@ -284,7 +284,7 @@ class MyLogger {
 
         $rc = @exec ( $command, $output, $status );
     
-        $output = implode($output, "\n");
+        $output = implode("\n", $output);
     
         $success = ( $status === 0 ) ? true : false;
         if (!$success) {

--- a/src/WalletDerive.php
+++ b/src/WalletDerive.php
@@ -101,7 +101,7 @@ class WalletDerive
         }
 
         MyLogger::getInstance()->log( "Deriving keys", MyLogger::info );
-        $path_base = is_numeric( $params['path']{0} ) ?  'm/' . $params['path'] : $params['path'];
+        $path_base = is_numeric( $params['path'][0] ) ?  'm/' . $params['path'] : $params['path'];
         
         // Allow paths to end with i or i'.
         // i' specifies that addresses should be hardened.


### PR DESCRIPTION
The legacy order of `implode()` arguments and usage of curly brackets for accessing array items will be removed with PHP 8 and already throws deprecation warnings starting with PHP 7.4 (to be released soon).

I found these with the [PHPCompatibility tool](https://github.com/PHPCompatibility/PHPCompatibility).