### PR TITLE
Remove include

### DIFF
--- a/src/WalletDerive.php
+++ b/src/WalletDerive.php
@@ -2,8 +2,6 @@
 
 namespace App;
 
-require_once __DIR__  . '/../vendor/autoload.php';
-
 // For HD-Wallet Key Derivation
 use BitWasp\Bitcoin\Bitcoin;
 use BitWasp\Bitcoin\Key\Factory\HierarchicalKeyFactory;


### PR DESCRIPTION
When using the WalletDerive class in another project, the include of autoload causes a conflict.

By removing the include, WalletDerive can be used as a component in other projects.